### PR TITLE
Fix manifest match pattern

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,10 @@
   "name": "Crunchyroll Watchlist Enhancer",
   "version": "1.0",
   "description": "Enhances the Crunchyroll watchlist page by organizing and styling sections.",
-  "host_permissions": ["https://www.crunchyroll.com/watchlist"],
+  "host_permissions": ["https://www.crunchyroll.com/watchlist*"],
   "content_scripts": [
     {
-      "matches": ["https://www.crunchyroll.com/watchlist"],
+      "matches": ["https://www.crunchyroll.com/watchlist*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- support watchlist pages with parameters or trailing slashes by adding a `*` wildcard to the match pattern

## Testing
- `cat manifest.json | python3 -m json.tool`

------
https://chatgpt.com/codex/tasks/task_e_684221c859b8833292287dd95e305c78