### PR TITLE
Fix repo clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight Chrome extension to reorganize Crunchyroll's watchlist into clear,
 
 1. **Clone or download the repository**:
    ```bash
-   git clone https://github.com/yourusername/crunchyroll-watchlist-enhancer.git
+   git clone https://github.com/yourusername/crunchyroll-better-watchlist.git
    ```
 2. **Load as an unpacked extension**:
    - Go to `chrome://extensions/` in your browser.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight Chrome extension to reorganize Crunchyroll's watchlist into clear,
 
 1. **Clone or download the repository**:
    ```bash
-   git clone https://github.com/yourusername/crunchyroll-better-watchlist.git
+   git clone https://github.com/renzofp/crunchyroll-better-watchlist.git
    ```
 2. **Load as an unpacked extension**:
    - Go to `chrome://extensions/` in your browser.


### PR DESCRIPTION
## Summary
- fix README clone URL to crunchyroll-better-watchlist.git

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68422327c4cc8332b501c25269e29c66